### PR TITLE
Jkdba dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Installers/KeePassLib_Encoded.txt
 .vscode/launch.json
 Test/recycle.log
 KeePassConfiguration.xml
+Test/Includes/MasterKeyWindowsAuth.kdbx

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ PSKeePass-1/KeePassLibrary2.3.dll
 Installers/KeePassLib_Encoded.txt
 .vscode/launch.json
 Test/recycle.log
+KeePassConfiguration.xml

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -1,4 +1,6 @@
-﻿function Get-KeePassEntry
+﻿##DEV
+## This can be updated to be a wrapper for get-kpentry
+function Get-KeePassEntry
 {
     <#
         .SYNOPSIS
@@ -219,6 +221,8 @@
     }
 }
 
+##DEV
+## This can be updated to be a wrapper to add-kpentry
 function New-KeePassEntry
 {
     <#
@@ -305,7 +309,7 @@ function New-KeePassEntry
         [String] $Notes
     )
 
-    #Check if an entry with the same name already exists in the same database in the same TopLevelGroup
+    ## Check if an entry with the same name already exists in the same database in the same TopLevelGroup
 
     if ($DBPath)
     {
@@ -317,7 +321,7 @@ function New-KeePassEntry
     }
 
     try{
-        #Read the global configuration
+        ## Read the global configuration
         [xml]$Configuration = (Get-Content $PSScriptRoot\KeePassConfiguration.xml)
         $KPProgramfolder = $Configuration.Settings.KeePassSettings.KPProgramFolder
         $DBDefaultpathPath = $Configuration.Settings.KeePassSettings.DBDefaultpathPath
@@ -406,9 +410,9 @@ function New-KeePassEntry
             Throw $ErrorMessage
         }
 
-        #check if an entry with this title in this group already exists
+        ## check if an entry with this title in this group already exists
 
-        #$Entryexists = (get-KeePassEntry -DBcredential $DBcredential -Title $Title -TopLevelGroupname $TopLevelGroupName)
+        ## $Entryexists = (get-KeePassEntry -DBcredential $DBcredential -Title $Title -TopLevelGroupname $TopLevelGroupName)
         if ($Entryexists -like 'ERROR: * not found')
         {
 
@@ -461,6 +465,8 @@ function New-KeePassEntry
     }
 }
 
+##DEV
+## This can be Updated to be a wrapper to set-kpentry 
 function Set-KeePassEntry
 {
     <#
@@ -791,7 +797,7 @@ function Set-KeePassEntry
   }
 }
 
-## Generates a Password Using the KeePass Password Generator
+##DEV
 ## Need to check if profile by name exists and prompt for what to do
 ## Need to add option to generate via profile
 function Get-KeePassPassword
@@ -1123,7 +1129,6 @@ function Get-KeePassConfiguration
 # *Their intended purpose is to be used for advanced scripting.
 #>
 
-## Saves a Password Profile to XML Config
 function New-KPPasswordProfile
 {
     <#
@@ -1142,13 +1147,13 @@ function New-KPPasswordProfile
     if (Test-Path -Path $PSScriptRoot\KeePassConfiguration.xml)
     {
         [xml] $XML = Get-Content("$PSScriptRoot\KeePassConfiguration.xml")
-        #Create New Profile Element with Name of the new profile
+        ## Create New Profile Element with Name of the new profile
         $PasswordProfile = $XML.CreateElement('Profile')
         $PasswordProfileAtribute = $XML.CreateAttribute('Name')
         $PasswordProfileAtribute.Value = $KeePassPasswordObject.ProfileName
         $PasswordProfile.Attributes.Append($PasswordProfileAtribute) | Out-Null
         
-        #Build and Add Element Nodes
+        ## Build and Add Element Nodes
         $CharacterSetNode = $XML.CreateNode('element','CharacterSet','')
         $CharacterSetNode.InnerText = $KeePassPasswordObject.CharacterSet
         $PasswordProfile.AppendChild($CharacterSetNode) | Out-Null
@@ -1179,6 +1184,7 @@ function New-KPPasswordProfile
     }
 }
 
+##DEV
 ## Need to build out this dummy function
 function Get-KPPasswordProfile
 {
@@ -1188,6 +1194,7 @@ function Get-KPPasswordProfile
     param()  
 }
 
+##DEV
 ## Need to build out this dummy function
 function Set-KPPasswordProfile
 {
@@ -1260,7 +1267,7 @@ function Get-KPCredential
     {
         try
         {
-            $output = [Ordered]@{
+            $Output = [Ordered] @{
                 'DatabaseFile' = $DatabaseFile
                 'KeyFile' = $KeyFile
                 'MasterKey' = $MasterKey
@@ -1274,7 +1281,7 @@ function Get-KPCredential
         }
         finally
         {
-            [PSCustomObject]$output
+            [PSCustomObject] $Output
         }
     }
 }
@@ -1318,7 +1325,7 @@ function Get-KPConnection
     )
     process
     {
-        #Create IOConnectionInfo to KPDB using KPLib
+        ## Create IOConnectionInfo to KPDB using KPLib
         try
         {
             $KeePassIOConnectionInfo = New-Object KeePassLib.Serialization.IOConnectionInfo
@@ -1331,11 +1338,9 @@ function Get-KPConnection
             Throw $_.Exception
         }
 
-        #Determine AuthenticationType and Create KPLib CompositeKey
+        ## Determine AuthenticationType and Create KPLib CompositeKey
         try
         {
-            
-
             if ($KeePassCredential.AuthenticationType -eq "Key")
             {
                 $KeePassCompositeKey.AddUserKey((New-Object KeePassLib.Keys.KcpKeyFile($KeePassCredential.KeyFile)))
@@ -1349,7 +1354,6 @@ function Get-KPConnection
                 $KeePassCompositeKey.AddUserKey((New-Object KeePassLib.Keys.KcpKeyFile($KeePassCredential.KeyFile)))
 
                 $KeePassCompositeKey.AddUserKey((New-Object KeePassLib.Keys.KcpPassword([Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($KeePassCredential.MasterKey)))))
-                
                 # $KeePassCompositeKey.AddUserKey((New-Object KeePassLib.Keys.KcpUserAccount))
             }
             elseif ($KeePassCredential.AuthenticationType -eq "Master")
@@ -1360,8 +1364,6 @@ function Get-KPConnection
                     $KeePassCompositeKey.AddUserKey((New-Object KeePassLib.Keys.KcpUserAccount))
                 }
             }
-
-            
         }
         catch [Exception]
         {
@@ -1370,17 +1372,14 @@ function Get-KPConnection
         }
         finally
         {
-            Remove-Variable -Name KeePassCredential
-            # $KeePassCompositeKey = $null
+            if($KeePassCredential){Remove-Variable -Name KeePassCredential}
         }
 
-        #Open KPDB Connection
+        ## Open KPDB Connection
         try
         {
             $KeePassDatabase = New-Object KeePassLib.PwDatabase
-            $KeePassDatabase.Open($KeePassIOConnectionInfo,$KeePassCompositeKey,$null)
-           
-            
+            $KeePassDatabase.Open($KeePassIOConnectionInfo, $KeePassCompositeKey, $null)
         }
         catch [Exception]
         {
@@ -1389,9 +1388,10 @@ function Get-KPConnection
         }
         finally
         {
-             Remove-Variable -Name KeePassCompositeKey
+            if($KeePassCompositeKey){Remove-Variable -Name KeePassCompositeKey}
         }
         
+        ## Return Open KeePass Database
         $KeePassDatabase
     }
 }
@@ -1421,7 +1421,16 @@ function Remove-KPConnection
     {
         try
         {
-            $KeePassConnection.Close()
+            ## Close KeePass Database Connection
+            if( $KeePassConnection.IsOpen)
+            {
+                $KeePassConnection.Close()
+            }
+            else
+            {
+                Write-Warning -Message "[PROCESS] The KeePass Database Specified is already closed or does not exist."    
+            }
+            
         }
         catch [Exception]
         {
@@ -1486,6 +1495,15 @@ function Get-KPEntry
         [ValidateNotNullOrEmpty()]
         [string] $UserName
     )
+    begin
+    {
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
+    }
     process
     {
         ## Get Entries and Filter
@@ -1522,6 +1540,8 @@ function Get-KPEntry
                  }
              }
         }
+
+        ## Return results
         $KeePassItems
     }
 }
@@ -1587,6 +1607,14 @@ function Add-KPEntry
     )
     begin
     {
+
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
+
         try
         {
             $KeePassEntry = New-Object KeePassLib.PwEntry($true, $true) -ErrorAction Stop -ErrorVariable ErrorNewPwEntryObject
@@ -1725,6 +1753,12 @@ function Set-KPEntry
     )
     begin
     {
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
         # try
         # {
         #     $KeePassEntry = New-Object KeePassLib.PwEntry($true, $true) -ErrorAction Stop -ErrorVariable ErrorNewPwEntryObject
@@ -1838,6 +1872,14 @@ function Remove-KPEntry
     )
     begin
     {
+
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
+
         $RecycleBin = Get-KPGroup -KeePassConnection $KeePassConnection -FullPath 'Recycle Bin'
         $EntryDisplayName = "$($KeePassEntry.ParentGroup.GetFullPath('/',$false))/$($KeePassEntry.Strings.ReadSafe('Title'))"
         
@@ -1946,6 +1988,13 @@ function Get-KPGroup
     )
     begin
     {
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
+
         try
         {
             [KeePassLib.PwGroup[]] $KeePassOutGroups = $null
@@ -2047,6 +2096,13 @@ function Add-KPGroup
     )
     begin
     {
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
+
         try
         {
             [KeePassLib.PwGroup] $KeePassGroup = New-Object KeePassLib.PwGroup -ErrorAction Stop -ErrorVariable ErrorNewPwGroupObject
@@ -2136,6 +2192,12 @@ function Set-KPGroup
     )
     begin
     {
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
         # try
         # {
         #     [KeePassLib.PwGroup] $KeePassGroup = New-Object KeePassLib.PwGroup -ErrorAction Stop -ErrorVariable ErrorNewPwGroupObject
@@ -2224,6 +2286,13 @@ function Remove-KPGroup
     )
     begin
     {
+        ## Check if database is open.
+        if(-not $KeePassConnection.IsOpen)
+        {
+            Write-Warning -Message '[BEGIN] The KeePass Connection Sepcified is not open or does not exist.'
+            break
+        }
+
         $RecycleBin = Get-KPGroup -KeePassConnection $KeePassConnection -FullPath 'Recycle Bin'
         
         if ( $Force -or $PSCmdlet.ShouldProcess($($KeePassGroup.GetFullPath('/',$false))))
@@ -2271,7 +2340,7 @@ function Remove-KPGroup
         # }
     }
     process
-    {        
+    {
         if($RecycleBin -and -not $NoRecycle)
         {
             #Make Copy of the group to be recycled.

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -1229,22 +1229,53 @@ function New-KeePassDatabaseConfiguration
 }
 
 ##DEV
-## Add Dynamic parameter to get a list of profiles
 ## Needs Documentation
 function Remove-KeePassDatabaseConfiguration 
 {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact='High')]
-    param
-    (
-        [Parameter(
-            Position = 0,
-            Mandatory = $true,
-            ValueFromPipelineByPropertyName = $true
-        )]
-        [ValidateNotNullOrEmpty()]
-        [Alias('Name')]
-        [String] $DatabaseProfileName
-    )
+    param()
+    dynamicparam
+    {
+        ##Create and Define Validate Set Attribute
+        $DatabaseProfileList =  (Get-KeePassDatabaseConfiguration).Name
+        if($DatabaseProfileList)
+        {
+            $ParameterName = 'DatabaseProfileName'
+            $AttributeCollection = New-Object -TypeName System.Collections.ObjectModel.Collection[System.Attribute]
+            ###ParameterSet Host
+            $ParameterAttribute = New-Object -TypeName System.Management.Automation.ParameterAttribute
+            $ParameterAttribute.Mandatory = $true
+            $ParameterAttribute.Position = 0
+            $ParameterAttribute.ValueFromPipelineByPropertyName = $true
+            # $ParameterAttribute.ParameterSetName = 'Profile'
+            $AttributeCollection.Add($ParameterAttribute)
+
+            $ValidateSetAttribute = New-Object -TypeName System.Management.Automation.ValidateSetAttribute($DatabaseProfileList)
+            $AttributeCollection.Add($ValidateSetAttribute)
+
+            ##Create and Define Allias Attribute
+            $AliasAttribute = New-Object -TypeName System.Management.Automation.AliasAttribute('Name')
+            $AttributeCollection.Add($AliasAttribute)
+
+            ##Create,Define, and Return DynamicParam
+            $RuntimeParameter = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
+            $RuntimeParameterDictionary = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameterDictionary
+            $RuntimeParameterDictionary.Add($ParameterName,$RuntimeParameter)
+            return $RuntimeParameterDictionary
+        }
+    }
+    begin
+    {
+        if($DatabaseProfileList)
+        {
+            $DatabaseProfileName = $PSBoundParameters[$ParameterName]
+        }
+        else
+        {
+            Write-Warning -Message "[BEGIN] There are Currently No Database Configuration Profiles." 
+            break
+        }
+    }
     process
     {
         if (-not (Test-Path -Path $PSScriptRoot\KeePassConfiguration.xml))
@@ -1283,7 +1314,6 @@ function Remove-KeePassDatabaseConfiguration
 }
 
 ##DEV
-## Add Dynamic parameter to get a list of profiles
 ## Needs Documentation
 function Get-KeePassDatabaseConfiguration
 {

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -225,60 +225,58 @@ function Get-KeePassEntry_1
 {
     param
     (
-        [Parameter(
-            Position = 0,
-            Mandatory = $false
-        )]
-        [ValidateNotNullOrEmpty()]
-        [String] $KeePassDatabaseFile,
-
-        [Parameter(
-            Position = 1,
-            Mandatory = $false
-        )]
-        [ValidateNotNullOrEmpty()]
-        [String] $KeePassKeyFile,
-
-        [Parameter(
-            Position = 2,
-            Mandatory = $false
-        )]
-        [ValidateNotNullOrEmpty()]
-        [securestring] $KeePassMasterKey,
-
-        [Parameter(
-            Postion = 3,
-            Mandatory = $false
-        )]
-        [Switch] $UseNetworkAccount,
-
-        [Parameter(
-            Position = 4,
-            Mandatory = $false
-        )]
+        [Parameter(Position = 0 ,Mandatory = $false, ParameterSetName='AutoAuth')]
+        [Parameter(Position = 0 ,Mandatory = $false, ParameterSetName='Key')]
+        [Parameter(Position = 0 ,Mandatory = $false, ParameterSetName='Master')]
+        [Parameter(Position = 0 ,Mandatory = $false, ParameterSetName='KeyAndMaster')]
+        [Parameter(Position = 0 ,Mandatory = $false, ParameterSetName='Network')]
         [ValidateNotNullOrEmpty()]
         [String] $KeePassEntryGroupPath,
 
-        [Parameter(
-            Position = 5,
-            Mandatory = $false
-        )]
+        [Parameter(Position = 1 ,Mandatory = $false, ParameterSetName='AutoAuth')]
+        [Parameter(Position = 1 ,Mandatory = $false, ParameterSetName='Key')]
+        [Parameter(Position = 1 ,Mandatory = $false, ParameterSetName='Master')]
+        [Parameter(Position = 1 ,Mandatory = $false, ParameterSetName='KeyAndMaster')]
+        [Parameter(Position = 1 ,Mandatory = $false, ParameterSetName='Network')]
         [ValidateNotNullOrEmpty()]
         [String] $KeePassEntryTitle,
 
-        [Parameter(
-            Position = 6,
-            Mandatory = $false,
-            ValueFromPipeline = $true
-        )]
+        [Parameter(Position = 2 ,Mandatory = $false, ValueFromPipeline = $true, ParameterSetName='AutoAuth')]
+        [Parameter(Position = 2 ,Mandatory = $false, ValueFromPipeline = $true, ParameterSetName='Key')]
+        [Parameter(Position = 2 ,Mandatory = $false, ValueFromPipeline = $true, ParameterSetName='Master')]
+        [Parameter(Position = 2 ,Mandatory = $false, ValueFromPipeline = $true, ParameterSetName='KeyAndMaster')]
+        [Parameter(Position = 2 ,Mandatory = $false, ValueFromPipeline = $true, ParameterSetName='Network')]
         [ValidateNotNullOrEmpty()]
         [String] $KeePassEntryUserName,
 
-        [Parameter(
-            Position = 7,
-            Mandatory = $false
-        )]
-        [Switch] $AsPlainText
+        [Parameter(Position = 3 ,Mandatory = $false, ParameterSetName='AutoAuth')]
+        [Parameter(Position = 3 ,Mandatory = $false, ParameterSetName='Key')]
+        [Parameter(Position = 3 ,Mandatory = $false, ParameterSetName='Master')]
+        [Parameter(Position = 3 ,Mandatory = $false, ParameterSetName='KeyAndMaster')]
+        [Parameter(Position = 3 ,Mandatory = $false, ParameterSetName='Network')]
+        [Switch] $AsPlainText,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='Key')]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='Master')]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='KeyAndMaster')]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='Network')]
+        [ValidateNotNullOrEmpty()]
+        [string] $DatabaseFile,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='Key')]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='KeyAndMaster')]
+        [ValidateNotNullOrEmpty()]
+        [string] $KeyFile,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='Master')]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$false, ParameterSetName='KeyAndMaster')]
+        [ValidateNotNullOrEmpty()]
+        [System.Security.SecureString] $MasterKey,
+
+        [Parameter(Mandatory=$false, ValueFromPipeline=$false, ParameterSetName='Network')]
+        [Parameter(Mandatory=$false, ValueFromPipeline=$false, ParameterSetName='Key')]
+        [Parameter(Mandatory=$false, ValueFromPipeline=$false, ParameterSetName='Master')]
+        [switch] $UseNetworkAccount
     )
     begin
     {

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -791,7 +791,6 @@ function Set-KeePassEntry
   }
 }
 
-
 ## Generates a Password Using the KeePass Password Generator
 ## Need to check if profile by name exists and prompt for what to do
 ## Need to add option to generate via profile

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -221,6 +221,37 @@ function Get-KeePassEntry
     }
 }
 
+function Get-KeePassEntry_1
+{
+    param
+    (
+        #Params
+        #matching parameter sets as get-kpentry
+        #db file
+        #db auth Params
+        #group name/path
+        #username
+        #title
+        #switch to return as powershell object (aka plain text)
+        #allow username from pipeline 
+    )
+    begin
+    {
+        #build connection if no db params are specified.
+        ##use config file
+        ###error if no db params and no config file
+        #open connection
+    }
+    process
+    {
+        #make get-kpentry call and return data
+    }
+    end
+    {
+        #clean up connection details
+    }
+}
+
 ##DEV
 ## This can be updated to be a wrapper to add-kpentry
 function New-KeePassEntry

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -899,14 +899,14 @@ function Get-KeePassPassword
     )
     process
     {
-        #Create New Password Profile.
+        ## Create New Password Profile.
         $PassProfile = New-Object KeePassLib.Cryptography.PasswordGenerator.PwProfile
         $NewProfileObject = '' | Select-Object ProfileName,CharacterSet,ExcludeLookAlike,NoRepeatingCharacters,ExcludeCharacters,Length
         
         if($PSBoundParameters.Count -gt 0)
         {
             $PassProfile.CharSet = New-Object KeePassLib.Cryptography.PasswordGenerator.PwCharSet
-            #Build Profile With Options.
+            ## Build Profile With Options.
             if($UpperCase)
             { 
                 $NewProfileObject.CharacterSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -995,14 +995,13 @@ function Get-KeePassPassword
                 New-KPPasswordProfile -KeePassPasswordObject $NewProfileObject
             }
         }
-        #Create Pass Generator Profile Pool.
+        ## Create Pass Generator Profile Pool.
         $GenPassPool = New-Object KeePassLib.Cryptography.PasswordGenerator.CustomPwGeneratorPool
-        #Create Out Parameter aka [rel] param.
+        ## Create Out Parameter aka [rel] param.
         [KeePassLib.Security.ProtectedString]$PSOut = New-Object KeePassLib.Security.ProtectedString
-        #Generate Password.
+        ## Generate Password.
         [KeePassLib.Cryptography.PasswordGenerator.PwGenerator]::Generate([ref] $PSOut, $PassProfile, $null, $GenPassPool) > $null
         # $PSOut.GetType();
-
         $PSOut
     }
 }
@@ -1052,7 +1051,7 @@ function Set-KeePassConfiguration
         [PSCustomObject] $PassProfile
     )
 
-    #Check if there already is a KeePassConfiguration.xml which can be used / overwritten
+    ## Check if there already is a KeePassConfiguration.xml which can be used / overwritten
     if (Test-Path -Path $PSScriptRoot\KeePassConfiguration.xml)
     {
 
@@ -1090,7 +1089,6 @@ function Set-KeePassConfiguration
 
         Write-Output 'KeePass configuration successfully created. To update, run Set-KeePassConfiguration again'
     }
-
 }
 
 function Get-KeePassConfiguration
@@ -1102,7 +1100,7 @@ function Get-KeePassConfiguration
             Reads the current KeePassConfiguration and displays values for DBDefaultpathPath and KPProgramfolder for the PowerShell KeePass Module.
             The KeePassConfiguration.xml is located in the PSKeePass module root folder.
     #>
-    #Check if there already is a KeePassConfiguration.xml and write out the configuration
+    ## Check if there already is a KeePassConfiguration.xml and write out the configuration
     if (Test-Path -Path $PSScriptRoot\KeePassConfiguration.xml)
     {
         [xml]$XML = (Get-Content $PSScriptRoot\KeePassConfiguration.xml)
@@ -1199,7 +1197,6 @@ function Set-KPPasswordProfile
     param()  
 }
 
-## Create a KeePass Credential Object
 function Get-KPCredential
 {
 	<#
@@ -1282,7 +1279,6 @@ function Get-KPCredential
     }
 }
 
-## Open KeePass DB Connection
 function Get-KPConnection
 {
     <#
@@ -1400,7 +1396,6 @@ function Get-KPConnection
     }
 }
 
-## Close KeePass DB connection
 function Remove-KPConnection
 {
     <#
@@ -1435,7 +1430,6 @@ function Remove-KPConnection
     }
 }
 
-## Fetch a KeePass entry
 function Get-KPEntry
 {
     <#
@@ -1494,10 +1488,10 @@ function Get-KPEntry
     )
     process
     {
-        #Get Entries and Filter
+        ## Get Entries and Filter
         $KeePassItems = $KeePassConnection.RootGroup.GetEntries($true)
 
-        #This a lame way of filtering.
+        ## This a lame way of filtering.
         if ($KeePassGroup)
         {
             $KeePassItems = foreach($_keepassItem in $KeePassItems)
@@ -1532,7 +1526,6 @@ function Get-KPEntry
     }
 }
 
-## Add New KeePass Entry
 function Add-KPEntry
 {
     <#
@@ -1784,29 +1777,25 @@ function Set-KPEntry
             $KeePassEntry.Strings.Set("URL", $SecureURL)
         }
         
-        #If specified group is different than current group
+        ## If specified group is different than current group
         if($KeePassGroup.Uuid -ne $KeePassEntry.Uuid)
         {
-            #Make Full Copy of Entry
+            ## Make Full Copy of Entry
             $NewKeePassEntry = $KeePassEntry.CloneDeep()
-            #Assign New Uuid to CloneDeep
+            ## Assign New Uuid to CloneDeep
             $NewKeePassEntry.Uuid = New-Object KeePassLib.PwUuid($true)
-            #Add Clone to Specified group
+            ## Add Clone to Specified group
             $KeePassGroup.AddEntry($NewKeePassEntry)
-            
-            #Save for safety
+            ## Save for safety
             $KeePassConnection.Save($null)
-            
-            #Delete previous entry
+            ## Delete previous entry
             $KeePassEntry.ParentGroup.Entries.Remove($KeePassEntry)
         }
-
-        #save database
+        ## save database
         $KeePassConnection.Save($null)
     }
 }
 
-## Removes a KeePassEntry
 function Remove-KPEntry
 {
     <#
@@ -1896,7 +1885,6 @@ function Remove-KPEntry
     }
 }
 
-## Gets a KeePass Group object
 function Get-KPGroup
 {
     <#
@@ -2009,7 +1997,6 @@ function Get-KPGroup
     end{ $KeePassOutGroups }
 }
 
-## Create a New KeePass Group
 function Add-KPGroup
 {
     <#
@@ -2195,7 +2182,6 @@ function Set-KPGroup
     }
 }
 
-## Removes a KeePassGroup
 function Remove-KPGroup
 {
     <#
@@ -2313,7 +2299,6 @@ function Remove-KPGroup
     }
 }
 
-#reads string from KeePassLib.Security.ProtectedString
 function ConvertFrom-KPProtectedString
 {
     <#
@@ -2344,7 +2329,6 @@ function ConvertFrom-KPProtectedString
     }
 }
 
-#creates a powershell object from one or more keepass entries.
 function ConvertTo-KPPSObject
 {
     <#

--- a/PSKeePass.psm1
+++ b/PSKeePass.psm1
@@ -225,15 +225,60 @@ function Get-KeePassEntry_1
 {
     param
     (
-        #Params
-        #matching parameter sets as get-kpentry
-        #db file
-        #db auth Params
-        #group name/path
-        #username
-        #title
-        #switch to return as powershell object (aka plain text)
-        #allow username from pipeline 
+        [Parameter(
+            Position = 0,
+            Mandatory = $false
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String] $KeePassDatabaseFile,
+
+        [Parameter(
+            Position = 1,
+            Mandatory = $false
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String] $KeePassKeyFile,
+
+        [Parameter(
+            Position = 2,
+            Mandatory = $false
+        )]
+        [ValidateNotNullOrEmpty()]
+        [securestring] $KeePassMasterKey,
+
+        [Parameter(
+            Postion = 3,
+            Mandatory = $false
+        )]
+        [Switch] $UseNetworkAccount,
+
+        [Parameter(
+            Position = 4,
+            Mandatory = $false
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String] $KeePassEntryGroupPath,
+
+        [Parameter(
+            Position = 5,
+            Mandatory = $false
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String] $KeePassEntryTitle,
+
+        [Parameter(
+            Position = 6,
+            Mandatory = $false,
+            ValueFromPipeline = $true
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String] $KeePassEntryUserName,
+
+        [Parameter(
+            Position = 7,
+            Mandatory = $false
+        )]
+        [Switch] $AsPlainText
     )
     begin
     {


### PR DESCRIPTION
Added Password Profile Functionality.
Added Database Configuration Profile Functionality (allows multiple databases.)
Added Windows Network Account Authentication.
Updated Get-KeePassEntry, Set-KeePassEntry and New-KeePassEntry:

1. Now Uses backend code base.
2. Requries a KeePassDatabase Configuration Profile. This Allows for much faster authentication to the database.
3. Auto Authentication to the database. Will prompt for maste key password if used.
4. Selecting a database config profile is easy and uses a dynamic parameter with an available list to choose from.
5. Now supports Getting, Setting (\moving), and Adding entries to and from a specific database paths.

Get-KeePassEntry will return all entries if no database path is specified. There is also an option to return as plain text. this will return all found entries as powershell object with all keepass-secure strings converted to text.